### PR TITLE
Update estlintrc.json schema with support for `ignorePatterns`

### DIFF
--- a/src/schemas/json/eslintrc.json
+++ b/src/schemas/json/eslintrc.json
@@ -527,6 +527,13 @@
       "description": "By default, ESLint will look for configuration files in all parent folders up to the root directory. This can be useful if you want all of your projects to follow a certain convention, but can sometimes lead to unexpected results. To limit ESLint to a specific project, set this to `true` in a configuration in the root of your project.",
       "type": "boolean"
     },
+    "ignorePatterns": {
+      "description": "Tell ESLint to ignore specific files and directories. Each value uses the same pattern as the `.eslintignore` file.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "rules": {
       "description": "ESLint comes with a large number of rules. You can modify which rules your project uses either using configuration comments or configuration files.",
       "type": "object",


### PR DESCRIPTION
With ESLint v6.7.0 came a new `ignorePatterns` option for config files and the current `eslintrc` schema does not have support for this new option. This PR should update the `eslintrc` schema with support for `ignorePatterns`.